### PR TITLE
Update tt-rss submodule to most recent version, light edits to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /.env
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tt-rss"]
 	path = tt-rss
-	url = https://tt-rss.org/git/tt-rss.git
+	url = https://git.tt-rss.org/fox/tt-rss

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ If you have issues, feel free to bug report/submit pull request. Depending on sp
 
 
 ## Quick start
+> (note: the Deploy to Heroku button [doesn't support](https://devcenter.heroku.com/articles/heroku-button#requirements) projects with submodules, so this repo can't be auto-deployed. However, the instructions are pretty simple!)
 
-Supposing you have already a Heroku account and you have the toolbelt installed and configured in your environment:
+Supposing you have already a Heroku account and you have the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) installed:
 
 ```sh
 # clone this repository
@@ -24,7 +25,7 @@ $ heroku addons:create heroku-postgresql:hobby-dev
 # everything is ready, push! (this will take time)
 $ git push heroku master
 
-# and enjoy (credentials are admin:password, so go to change the password)
+# and enjoy (default credentials are admin:password; you should change the password immediately)
 $ heroku open
 ```
 


### PR DESCRIPTION
Thanks for putting together this excellent package of scripts! I'm a longtime tt-rss user and was glad to get it running on Heroku so easily.

I updated the tt-rss submodule to the most recent version, and changed its repo URL to match the new one at tt-rss.org. I also made some light edits to `README.md` for clarity.

I got partway through the process of enhancing `app.json` to enable a Deploy to Heroku button, but it turns out those [don't support git submodules](https://devcenter.heroku.com/articles/heroku-button#requirements) (unless you use a custom buildpack, and even then there are authentication issues), so I added a note to `README.md` to clarify that.